### PR TITLE
Remove erroneous comment about listener container blocking

### DIFF
--- a/worker/src/main/java/com/heroku/devcenter/BigOperationWorker.java
+++ b/worker/src/main/java/com/heroku/devcenter/BigOperationWorker.java
@@ -54,7 +54,6 @@ public class BigOperationWorker {
             }
         });
 
-        // start up the listener. this will block until JVM is killed.
         listenerContainer.start();
         System.out.println("BigOperationWorker started");
     }


### PR DESCRIPTION
This comment is wrong and misleading... Specifically it does not block, the main thread completes, but due to the listenerContainer threads being backgrounded, the JVM process does not exit till the listenerContainer threads complete.

This is confusing to people who don't understand how spring rabbit works....
